### PR TITLE
Add support for WCIF output from TNoodle 0.17+

### DIFF
--- a/src/components/Competition/Competition.jsx
+++ b/src/components/Competition/Competition.jsx
@@ -10,7 +10,6 @@ import { flatMap, updateIn } from '../../logic/utils';
 import { parseActivityCode } from '../../logic/wcif';
 import { getUniqueScrambleUploadedId } from '../../logic/import-export-wcif';
 import {
-  updateMultiAndFm,
   transformUploadedScrambles,
   allScramblesForEvent,
   usedScramblesIdsForEvent,
@@ -57,7 +56,6 @@ export default class Competition extends Component {
         newScramble.competitionName = `${getUniqueScrambleUploadedId()}: ${
           newScramble.competitionName
         }`;
-        newScramble = updateIn(newScramble, ['sheets'], updateMultiAndFm);
         newScramble = transformUploadedScrambles(newScramble);
         return {
           wcif: {

--- a/src/components/Competition/CompetitionInfo/MatchingScramblesPanel.jsx
+++ b/src/components/Competition/CompetitionInfo/MatchingScramblesPanel.jsx
@@ -53,7 +53,7 @@ const MatchingScramblesPanel = ({
               fullWidth
               className={classnames(classes.addJsonButton)}
             >
-              Upload scrambles json
+              Upload scrambles json from TNoodle
             </Button>
           </label>
         </Grid>

--- a/src/components/ImportWCIF/ImportWCIF.jsx
+++ b/src/components/ImportWCIF/ImportWCIF.jsx
@@ -116,7 +116,7 @@ const ImportWCIF = ({
   signedIn,
 }) => {
   const classes = useStyles();
-  const [tabValue, setTabValue] = useState(signedIn ? 'wca' : 'xlsx');
+  const [tabValue, setTabValue] = useState('wca');
 
   // Dirty hack to preload given WCIF
   //handleWcifJSONLoad(tmpWcif);
@@ -145,9 +145,9 @@ const ImportWCIF = ({
                 value={tabValue}
                 onChange={(event, value) => setTabValue(value)}
               >
-                <Tab label="XLSX file" value="xlsx" />
                 <Tab label="WCA import" value="wca" />
                 <Tab label="WCIF file" value="wcif" />
+                <Tab label="XLSX file" value="xlsx" />
               </Tabs>
               <div className={classes.tabContent}>
                 {tabValue === 'wca' && (

--- a/src/logic/scrambles.js
+++ b/src/logic/scrambles.js
@@ -130,7 +130,7 @@ export const updateMultiAndFm = scrambles =>
 
 export const transformUploadedScrambles = uploadedJson => {
   // Newer versions of TNoodle provide a pre-compiled WCIF that we can read here.
-  // Retain old version (below `if`) as well to have a "grace period" in transitioning
+  // Retain old version (`else` branch) as well to have a "grace period" in transitioning
   if ('wcif' in uploadedJson) {
     const tnoodleWcif = uploadedJson['wcif'];
     const [, extractedScrambles] = importWcif(tnoodleWcif);
@@ -139,13 +139,14 @@ export const transformUploadedScrambles = uploadedJson => {
       sheetExt => sheetExt['sheets']
     );
     return uploadedJson;
+  } else {
+    const updater = sheets =>
+      tnoodleSheetsToInternal(
+        uploadedJson.competitionName,
+        updateMultiAndFm(sheets)
+      );
+    return updateIn(uploadedJson, ['sheets'], updater);
   }
-  const updater = sheets =>
-    tnoodleSheetsToInternal(
-      uploadedJson.competitionName,
-      updateMultiAndFm(sheets)
-    );
-  return updateIn(uploadedJson, ['sheets'], updater);
 };
 
 // 65 is the char code for 'A'


### PR DESCRIPTION
The current development version of TNoodle has abandoned the manual `ScrambleSheets` format in favor of WCIF support. Most notably, this means that a pre-populated WCIF (i.e. including scrambles within the WCIF specification itself) will be provided with the "Interchange" JSON in the TNoodle folder.

This PR aims to add support for this exact feature. Implementation was pretty straight-forward because the code already had support for parsing WCIF `ScrambleSet` objects.

Two remarks:
1. I've left the old parsing mechanism in the code for now, so that both 15.3 and 17+ will continue to work with the scrambles matcher. We can consider removing the old mechanism after the "grace period" for 15.3 is over (once 17.X is actually released…)
2. The `importWcif` method that already existed before my PR did some pretty crazy stuff with packing the parsed sheets into a single-element array. I see why this would be possible from a `React` standpoint, but it forces me to deliberately *un*-pack that array before proceeding. Maybe a tad bit nasty but works, I'm open for suggestions.

Effectively I just use existing code to parse the WCIF into the pre-existing `sheets` structure. Since this is my first-ever JavaScript PR (yay?) you're absolutely required to test the hell out of it because I know JS typing can shoot you in the foot a lot and I don't have the necessary experience to put the bandages on in this case.