### PR TITLE
Fixes #14. Support FMC Groups

### DIFF
--- a/src/components/Scrambles/ScrambleList.jsx
+++ b/src/components/Scrambles/ScrambleList.jsx
@@ -75,7 +75,7 @@ const DraggableScramble = ({ s, index, showPrefix }) => (
 );
 
 const ScrambleList = ({ scrambles, holds, round }) => {
-  let showPrefix = holds.startsWith('round') && !round.id.startsWith('333fm');
+  let showPrefix = holds.startsWith('round');
   return (
     <Droppable droppableId={holds}>
       {(provided, snapshot) => (

--- a/src/logic/scrambles.js
+++ b/src/logic/scrambles.js
@@ -154,7 +154,7 @@ export const prefixForIndex = index => String.fromCharCode(65 + index);
 
 export const internalScramblesToWcifScrambles = (eventId, scrambles) => {
   if (scrambles.length === 0) return scrambles;
-  if (eventId === '333mbf') {
+  if (eventId === '333mbf' || eventId === '333fm') {
     // For all attempts, we want to push each of the scramble sequences to
     // their corresponding groups.
     let scramblesByAttempt = groupBy(scrambles, s => s.attemptNumber);
@@ -177,23 +177,6 @@ export const internalScramblesToWcifScrambles = (eventId, scrambles) => {
         })
       );
     return sheets;
-  } else if (eventId === '333fm') {
-    // We can't track yet in the WCIF which scramble was for witch attempt,
-    // so let's just sort them by attempt id and combine them in one
-    // scramble sheet.
-    // There is usually only one group for FM, the only case where we would
-    // like more scramble than expected is when something terrible happened
-    // and an extra was needed.
-    return [
-      {
-        id: scrambles[0].id,
-        scrambles: flatMap(
-          sortBy(scrambles, s => s.attemptNumber),
-          s => s.scrambles
-        ),
-        extraScrambles: [],
-      },
-    ];
   }
   return scrambles.map(set => ({
     id: set.id,


### PR DESCRIPTION
Changed fmc scramble matching to act the same as mbld scramble matching in having a group. 

FMC Groups shouldn't really happen, but it is possible. We should give the option to the Delegate in valid cases. There is a warning set up on the website if a Delegate has multiple groups and to provide an explanation to WRT; that should alleviate any cases which didn't use multiple groups.

I'll subsequently add an issue for having extras for attempt based rounds (FMC and MBLD).

Old:
![image](https://user-images.githubusercontent.com/11577241/103703020-d39cc780-4f74-11eb-96d3-b94741dddb5c.png)

New:
![image](https://user-images.githubusercontent.com/11577241/103703026-d8fa1200-4f74-11eb-91d0-567dbc9aafc1.png)
