### PR TITLE
Make scramble Ids unique. Again!

### DIFF
--- a/src/logic/import-export-wcif.js
+++ b/src/logic/import-export-wcif.js
@@ -77,12 +77,6 @@ export const importWcif = wcif => {
   // sheets.
 
   wcif = updateIn(wcif, ['events'], sortWcifEvents);
-  let all = flatMap(
-    flatMap(wcif.events, e => e.rounds),
-    r => r.scrambleSets || []
-  );
-  uniqueScrambleSetId =
-    all.length === 0 ? 1 : Math.max(...all.map(s => s.id)) + 1;
 
   let scrambleSheet = {
     id: uniqueScrambleUploadedId,


### PR DESCRIPTION
Issue:

The scramble id was being reset to the length of the scramble file on every import meaning that this "unique variable" can create duplicates, which it was, and causes issues with dragging in some instances.

I've removed this code as the only thing that references the uniqueScrambleSetId is when we generate a new id and we want to guarantee that they are unique.