### PR TITLE
Update to Draggable which allows only string draggableId

### DIFF
--- a/src/components/Scrambles/ScrambleList.jsx
+++ b/src/components/Scrambles/ScrambleList.jsx
@@ -51,7 +51,7 @@ const ScrambleItem = ({ title, subtitle }) => (
 );
 
 const DraggableScramble = ({ s, index, showPrefix }) => (
-  <Draggable draggableId={s.id} index={index}>
+  <Draggable draggableId={s.id.toString()} index={index}>
     {(provided, snapshot) => (
       <ListItem
         button


### PR DESCRIPTION
Recently we updated `react-beautiful-dnd` from 11.0.5 to 13.1.0. From version 12.0.0, they have made it mandatory that Ids should be string (reference: https://github.com/atlassian/react-beautiful-dnd/releases/). But our Id was number, because of which the dragging of scrambles was not working. This PR converts the number to string.