### PR TITLE
Only auto-assign up to `scrambleSetCount` scrambles

### DIFF
--- a/src/components/Competition/CompetitionInfo/MatchingScramblesPanel.jsx
+++ b/src/components/Competition/CompetitionInfo/MatchingScramblesPanel.jsx
@@ -20,10 +20,12 @@ const MatchingScramblesPanel = ({
       </Typography>
       <Typography paragraph align="justify">
         Clicking "Automatically assign scrambles" will attempt to automatically
-        detect which scrambles sets belongs to which round. Unlike the workbook
-        assistant, this will attempt to assign unused scrambles only to rounds{' '}
-        <b>without</b> scrambles! Which means that clicking several times the
-        button with the same uploaded scrambles will have no effect.
+        detect which scrambles sets belongs to which round, assigning up to the
+        number of scramble sets listed on the "Manage events" page on the WCA
+        website. Unlike the workbook assistant, this will attempt to assign
+        unused scrambles only to rounds <b>without</b> scrambles! Which means
+        that clicking several times the button with the same uploaded scrambles
+        will have no effect.
         <br />
         You can check scrambles assignments by browsing through the rounds in
         the menu. For each round (or each attempt for Multiple Blindfolded and

--- a/src/logic/scrambles.js
+++ b/src/logic/scrambles.js
@@ -103,7 +103,8 @@ const scrambleSetsForRound = (usedScramblesId, round, uploadedScrambles) => {
         attemptNumber: s.generatedAttemptNumber,
       }));
   } else {
-    return firstMatchingSheets;
+    // Only auto-assign up to scrambleSetCount sets of scrambles.
+    return firstMatchingSheets.slice(0, round.scrambleSetCount);
   }
 };
 


### PR DESCRIPTION
## Motivation

Many delegates generate extra scramble sets (generally 1 per event or 1 per round). This is really useful if things go horribly wrong during a group at a competition, since it allows a delegate to restart a group without having to regenerate additional scramble sets.

However, this is a huge pain when linking scramble sets, since it means manually having to remove the extra scramble set from _every_ event every time you submit results.

## Solution

When auto-assigning scrambles, only assign up to `round.scrambleSetCount` scramble sets. For example:

![example](https://github.com/thewca/scrambles-matcher/assets/24919355/70b23c04-ab20-4075-a18f-8b24ac080cf1)
