### PR TITLE
allow mbld and fmc to auto assign number of sets as per WCA

### DIFF
--- a/src/logic/scrambles.js
+++ b/src/logic/scrambles.js
@@ -98,6 +98,7 @@ const scrambleSetsForRound = (usedScramblesId, round, uploadedScrambles) => {
     let numberOfAttempts = formatById(round.format).solveCount;
     return firstMatchingSheets
       .filter((s) => s.generatedAttemptNumber <= numberOfAttempts)
+      .slice(0, round.scrambleSetCount * numberOfAttempts)
       .map((s) => ({
         ...s,
         attemptNumber: s.generatedAttemptNumber,


### PR DESCRIPTION
Autoassigning till the number of sets mentioned on WCA wasn't implemented for FMC and MBLD.

This will avoid the repetitive sanity check failure of `[Consistency of Results & Rounds Data] Inconsistent scramble counts in Scrambles table and rounds table`

I have also explained the bug in the email thread "Bug in scramble matcher."