### PR TITLE
Ignore H2H rounds

### DIFF
--- a/src/components/Competition/CompetitionMenu/CompetitionMenu.jsx
+++ b/src/components/Competition/CompetitionMenu/CompetitionMenu.jsx
@@ -58,27 +58,29 @@ const CompetitionMenu = ({ events, setSelectedRound }) => {
             unmountOnExit
           >
             <List dense={true}>
-              {event.rounds.map((round) => (
-                <ListItem
-                  key={round.id}
-                  button
-                  sx={{ paddingLeft: 4 }}
-                  onClick={() => setSelectedRound(round.id)}
-                >
-                  <ListItemText
-                    primary={
-                      roundTypeById(
-                        roundTypeIdForRound(event.rounds.length, round)
-                      ).name
-                    }
-                  />
-                  {!roundHasValidScrambles(event.id, round) && (
-                    <Tooltip title="Missing scrambles">
-                      <ReportProblemIcon color="error" />
-                    </Tooltip>
-                  )}
-                </ListItem>
-              ))}
+              {event.rounds
+                .filter((round) => round.format !== 'h')
+                .map((round) => (
+                  <ListItem
+                    key={round.id}
+                    button
+                    sx={{ paddingLeft: 4 }}
+                    onClick={() => setSelectedRound(round.id)}
+                  >
+                    <ListItemText
+                      primary={
+                        roundTypeById(
+                          roundTypeIdForRound(event.rounds.length, round)
+                        ).name
+                      }
+                    />
+                    {!roundHasValidScrambles(event.id, round) && (
+                      <Tooltip title="Missing scrambles">
+                        <ReportProblemIcon color="error" />
+                      </Tooltip>
+                    )}
+                  </ListItem>
+                ))}
             </List>
           </Collapse>
         </Fragment>

--- a/src/logic/import-export-wcif.js
+++ b/src/logic/import-export-wcif.js
@@ -39,20 +39,22 @@ export const internalWcifToResultsJson = (wcif, version) => {
       })),
     events: wcif.events.map((e) => ({
       eventId: e.id,
-      rounds: e.rounds.map((r) => ({
-        roundId: roundTypeIdForRound(e.rounds.length, r),
-        formatId: r.format,
-        results: r.results.map((res) => ({
-          personId: res.personId,
-          position: res.ranking,
-          results: res.attempts.map((a) => a.result),
-          best: res.best,
-          average: res.average,
+      rounds: e.rounds
+        .filter((r) => r.format !== 'h')
+        .map((r) => ({
+          roundId: roundTypeIdForRound(e.rounds.length, r),
+          formatId: r.format,
+          results: r.results.map((res) => ({
+            personId: res.personId,
+            position: res.ranking,
+            results: res.attempts.map((a) => a.result),
+            best: res.best,
+            average: res.average,
+          })),
+          groups: scramblesToResultsGroups(
+            internalScramblesToWcifScrambles(e.id, r.scrambleSets)
+          ),
         })),
-        groups: scramblesToResultsGroups(
-          internalScramblesToWcifScrambles(e.id, r.scrambleSets)
-        ),
-      })),
     })),
     // TODO: make sure that only one tnoodle was used, then add an explicit field for that?
     scrambleProgram: wcif.scrambleProgram,


### PR DESCRIPTION
Currently, the workflow for submitting results for competitions with H2H rounds requires WST to manually edit the Results JSON simply to remove the H2H rounds.

This PR would cause H2H rounds to be ignored both in the Results JSON download and in the UI, reducing that back-and-forth in the results submission, so we could implement a simpler workflow.